### PR TITLE
fix: remove botões desnecessários do yad modal para selecionar wallpaper

### DIFF
--- a/.config/ags/scripts/color_generation/switchwall.sh
+++ b/.config/ags/scripts/color_generation/switchwall.sh
@@ -33,7 +33,7 @@ else
 	# Select and set image (hyprland)
 
     cd "$(xdg-user-dir PICTURES)" || return 1
-	switch "$(yad --width 1200 --height 800 --file --add-preview --large-preview --title='Choose wallpaper')"
+	switch "$(yad --width 1200 --height 800 --file --add-preview --large-preview --title='Choose wallpaper' --no-buttons)"
 fi
 
 # Generate colors for ags n stuff


### PR DESCRIPTION
![image](https://github.com/JohnAnon9771/my-desktop-arch/assets/42195321/0832d807-5ba4-469d-8332-2694dc9c7261)
